### PR TITLE
feat: 新增单密钥轮询功能

### DIFF
--- a/internal/channel/base_channel.go
+++ b/internal/channel/base_channel.go
@@ -91,7 +91,23 @@ func (b *BaseChannel) BuildUpstreamURL(originalURL *url.URL, group *models.Group
 
 	finalURL.Path = strings.TrimRight(finalURL.Path, "/") + requestPath
 
-	finalURL.RawQuery = originalURL.RawQuery
+	// 过滤查询参数，移除用于内部控制的 'id' 参数
+	if originalURL.RawQuery != "" {
+		originalValues, err := url.ParseQuery(originalURL.RawQuery)
+		if err != nil {
+			return "", fmt.Errorf("failed to parse query parameters: %w", err)
+		}
+		
+		// 移除 'id' 参数，这是用于密钥选择的内部参数
+		filteredValues := url.Values{}
+		for key, values := range originalValues {
+			if key != "id" {
+				filteredValues[key] = values
+			}
+		}
+		
+		finalURL.RawQuery = filteredValues.Encode()
+	}
 
 	return finalURL.String(), nil
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -29,6 +29,7 @@ var (
 	ErrValidation         = &APIError{HTTPStatus: http.StatusBadRequest, Code: "VALIDATION_FAILED", Message: "Input validation failed"}
 	ErrDuplicateResource  = &APIError{HTTPStatus: http.StatusConflict, Code: "DUPLICATE_RESOURCE", Message: "Resource already exists"}
 	ErrResourceNotFound   = &APIError{HTTPStatus: http.StatusNotFound, Code: "NOT_FOUND", Message: "Resource not found"}
+	ErrNotFound           = &APIError{HTTPStatus: http.StatusNotFound, Code: "NOT_FOUND", Message: "Resource not found"}
 	ErrInternalServer     = &APIError{HTTPStatus: http.StatusInternalServerError, Code: "INTERNAL_SERVER_ERROR", Message: "An unexpected error occurred"}
 	ErrDatabase           = &APIError{HTTPStatus: http.StatusInternalServerError, Code: "DATABASE_ERROR", Message: "Database operation failed"}
 	ErrUnauthorized       = &APIError{HTTPStatus: http.StatusUnauthorized, Code: "UNAUTHORIZED", Message: "Authentication failed"}
@@ -38,6 +39,7 @@ var (
 	ErrNoActiveKeys       = &APIError{HTTPStatus: http.StatusServiceUnavailable, Code: "NO_ACTIVE_KEYS", Message: "No active API keys available for this group"}
 	ErrMaxRetriesExceeded = &APIError{HTTPStatus: http.StatusBadGateway, Code: "MAX_RETRIES_EXCEEDED", Message: "Request failed after maximum retries"}
 	ErrNoKeysAvailable    = &APIError{HTTPStatus: http.StatusServiceUnavailable, Code: "NO_KEYS_AVAILABLE", Message: "No API keys available to process the request"}
+	ErrKeyUnavailable     = &APIError{HTTPStatus: http.StatusServiceUnavailable, Code: "KEY_UNAVAILABLE", Message: "The specified API key is not available"}
 )
 
 // NewAPIError creates a new APIError with a custom message.

--- a/web/src/components/keys/KeyTable.vue
+++ b/web/src/components/keys/KeyTable.vue
@@ -16,6 +16,7 @@ import {
   RefreshCircleOutline,
   RefreshOutline,
   PauseCircleOutline,
+  LinkOutline,
 } from "@vicons/ionicons5";
 import {
   NButton,
@@ -256,6 +257,29 @@ async function copyKey(key: KeyRow) {
   const success = await copy(key.key_value);
   if (success) {
     window.$message.success("密钥已复制到剪贴板", {
+      duration: 3000,
+    });
+  } else {
+    window.$message.error("复制失败", {
+      duration: 3000,
+    });
+  }
+}
+
+async function copyKeyURL(key: KeyRow) {
+  if (!props.selectedGroup?.name) {
+    window.$message.error("分组信息不可用", {
+      duration: 3000,
+    });
+    return;
+  }
+  
+  const baseUrl = window.location.origin;
+  const proxyUrl = `${baseUrl}/proxy/${props.selectedGroup.name}?id=${key.id}`;
+  
+  const success = await copy(proxyUrl);
+  if (success) {
+    window.$message.success("代理URL已复制到剪贴板", {
       duration: 3000,
     });
   } else {
@@ -928,9 +952,14 @@ function cancelEditingRemarks(key: KeyRow) {
                     <n-icon :component="key.is_visible ? EyeOffOutline : EyeOutline" />
                   </template>
                 </n-button>
-                <n-button size="tiny" text @click="copyKey(key)" title="复制">
+                <n-button size="tiny" text @click="copyKey(key)" title="复制密钥">
                   <template #icon>
                     <n-icon :component="CopyOutline" />
+                  </template>
+                </n-button>
+                <n-button size="tiny" text @click="copyKeyURL(key)" title="复制URL">
+                  <template #icon>
+                    <n-icon :component="LinkOutline" />
                   </template>
                 </n-button>
               </div>


### PR DESCRIPTION
## 功能概述

实现了单密钥轮询功能，允许用户通过URL参数指定使用特定的密钥ID，而不是轮询整个密钥池。

## 核心特性

### 🎯 URL格式
- **单密钥模式**: `http://localhost:3001/proxy/nono?id=335/v1/messages?beta=true`
- **轮询模式**: `http://localhost:3001/proxy/nono/v1/messages?beta=true` (原有功能)

### 🔐 安全机制
- 验证密钥属于指定分组，防止跨分组访问
- 检查密钥状态（active/disabled）确保可用性
- 保持现有的认证和授权逻辑

## 实现详情

### 后端修改

#### 1. 密钥提供者 (`internal/keypool/provider.go`)
- 新增 `SelectKeyByID` 方法支持按ID选择密钥
- 包含完整的分组验证、状态检查和错误处理

#### 2. 代理服务器 (`internal/proxy/server.go`) 
- 修改 `HandleProxy` 支持解析URL中的 `id` 查询参数
- 新增 `executeRequestWithSpecificKey` 方法处理单密钥请求
- 保持完整的重试、错误处理和日志记录逻辑

#### 3. URL构建逻辑 (`internal/channel/base_channel.go`)
- 过滤内部 `id` 参数，确保不会传递给上游服务

#### 4. 错误处理 (`internal/errors/errors.go`)
- 新增 `ErrKeyUnavailable` 和 `ErrNotFound` 错误类型

### 前端修改

#### 密钥表格组件 (`web/src/components/keys/KeyTable.vue`)
- 新增"复制URL"按钮（链接图标），位于密钥卡片快速操作区域
- 实现 `copyKeyURL` 函数生成并复制包含密钥ID的代理URL
- 保持与现有UI风格的一致性

## 使用场景

1. **固定密钥测试**: 开发者可以指定特定密钥进行API测试
2. **密钥性能分析**: 监控特定密钥的表现和稳定性  
3. **用户偏好**: 允许用户选择使用特定的高性能密钥

## 兼容性

- ✅ 完全向下兼容，现有轮询功能不受影响
- ✅ 新功能通过可选查询参数实现
- ✅ 错误处理、重试机制与轮询模式保持一致
- ✅ 日志记录区分单密钥和轮询模式

## 测试验证

- ✅ 前端TypeScript类型检查通过
- ✅ 后端Go代码编译成功
- ✅ 构建流程正常运行

🤖 Generated with [Claude Code](https://claude.ai/code)